### PR TITLE
HyperSerialPico support

### DIFF
--- a/addon-hyperhdr/config.json
+++ b/addon-hyperhdr/config.json
@@ -38,6 +38,7 @@
     "SYS_RAWIO"
   ],
   "uart": true,
+  "udev": true,
   "usb": true,
   "video": true,
   "gpio": true,


### PR DESCRIPTION
Pass udev database from host to HyperHDR container to enable correct detection of HyperSerialPico based LED drivers.