### PR TITLE
Expose port 1900 to enable SSDP discovery

### DIFF
--- a/addon-hyperhdr/Dockerfile
+++ b/addon-hyperhdr/Dockerfile
@@ -21,6 +21,6 @@ RUN chmod a+x /run.sh
 RUN wget -q "${DOWNLOAD_URL}/v${BUILD_VERSION}/HyperHDR-${BUILD_VERSION}-Linux-$(uname -m).tar.gz" -O - | tar -xvz -C /usr
 
 VOLUME /config
-EXPOSE 8090 8092 19333 19400 19444 19445
+EXPOSE 8090 8092 19333 19400 19444 19445 1900
 RUN echo 'Running webUI on port 8090. Port 19444-19445 exposed for json, protobuffer server (screen-cap)'
 CMD [ "/run.sh" ]

--- a/addon-hyperhdr/config.json
+++ b/addon-hyperhdr/config.json
@@ -4,20 +4,19 @@
   "slug": "hyperhdr",
   "description": "Open source ambient lighting implementation based on video and audio streams analysis. Includes real-time HDR tone mapping and multi-threading.",
   "url": "https://github.com/awawa-dev/HyperHDR",
-  "arch": [
-    "amd64",
-    "aarch64"
-  ],
+  "arch": ["amd64", "aarch64"],
   "startup": "application",
   "apparmor": false,
   "boot": "auto",
+  "host_network": true,
   "ports": {
     "8090/tcp": 8090,
     "8092/tcp": null,
     "19333/tcp": 19333,
     "19400/tcp": 19400,
     "19444/tcp": 19444,
-    "19445/tcp": 19445
+    "19445/tcp": 19445,
+    "1900/udp": 1900
   },
   "ports_description": {
     "8090/tcp": "Web Admin",
@@ -25,18 +24,14 @@
     "19333/tcp": "Boblight Server",
     "19400/tcp": "Google Flatbuffers Receiver",
     "19444/tcp": "JSON-RPC Remote Control",
-    "19445/tcp": "Protocol Buffers Server"
+    "19445/tcp": "Protocol Buffers Server",
+    "1900/udp": "SSDP"
   },
-  "map": [
-    "config:rw"
-  ],
+  "map": ["config:rw"],
   "image": "noname93d/hyperhdr-addon-{arch}",
   "options": {},
   "schema": {},
-  "privileged": [
-    "SYS_ADMIN",
-    "SYS_RAWIO"
-  ],
+  "privileged": ["SYS_ADMIN", "SYS_RAWIO"],
   "uart": true,
   "udev": true,
   "usb": true,


### PR DESCRIPTION
This simple change expose port 1900 to enable SSDP discovery, I'm not sure if host_network: true in config.json is necessary.

My use case is using HyperTizen with this HA addons, I saw other users on forums not understanding why their HyperHDR server was not being discovered by HyperTizen.